### PR TITLE
[ADD] issue template for proposals

### DIFF
--- a/spec_update_issue_template.md
+++ b/spec_update_issue_template.md
@@ -1,17 +1,15 @@
-## Issue template for proposal to BIDS
---------------
+## Update proposal for BIDS Prov (BEP028)
+
 ### Problem Statement
-What type of enhancement ? Is it a `new feature or a modification` ?
-What `limitation in the current spec` does this underline ?
+*What type of enhancement ? Is it a `new feature or a modification` ?
+What `limitation in the current spec` does this underline ?*
 
---------------
 ### Rationale
-What `solution` do you propose ? How does that relate to the original problem ?
+*What `solution` do you propose ? How does that relate to the original problem ?*
 
---------------
 ### Minimal example
-Provide a minimal example with the current spec.
-How would this example turn if we `apply the proposed change` ?
+*Provide a minimal example with the current spec.
+How would this example turn if we `apply the proposed change` ?*
 
 -------------
 ### Checklist 

--- a/spec_update_issue_template.md
+++ b/spec_update_issue_template.md
@@ -15,8 +15,5 @@ How would this example turn if we `apply the proposed change` ?
 
 -------------
 ### Checklist 
-- [ ] link to the google doc of the proposal
-- [ ] make sure the google doc follows the [BIDS proposale template](https://docs.google.com/document/d/1W7--Mf3gCCb1mVfhsoRJCAKFhmf2umG1PFkyZ1jEgMw/edit#heading=h.4k1noo90gelw)
-- [ ] list of all authors for this proposal
-- [ ] links to related [issues](https://github.com/bids-standard/bids-specification/issues) and [PRs](https://github.com/bids-standard/bids-specification/pulls) in bids-specification
+- [ ] links to related existing [issues](https://github.com/bids-standard/BEP028_BIDSprov/issues) and/or [PR](https://github.com/bids-standard/BEP028_BIDSprov/pulls)
 

--- a/spec_update_issue_template.md
+++ b/spec_update_issue_template.md
@@ -1,0 +1,22 @@
+## Issue template for proposal to BIDS
+--------------
+### Problem Statement
+What type of enhancement ? Is it a `new feature or a modification` ?
+What `limitation in the current spec` does this underline ?
+
+--------------
+### Rationale
+What `solution` do you propose ? How does that relate to the original problem ?
+
+--------------
+### Minimal example
+Provide a minimal example with the current spec.
+How would this example turn if we `apply the proposed change` ?
+
+-------------
+### Checklist 
+- [ ] link to the google doc of the proposal
+- [ ] make sure the google doc follows the [BIDS proposale template](https://docs.google.com/document/d/1W7--Mf3gCCb1mVfhsoRJCAKFhmf2umG1PFkyZ1jEgMw/edit#heading=h.4k1noo90gelw)
+- [ ] list of all authors for this proposal
+- [ ] links to related [issues](https://github.com/bids-standard/bids-specification/issues) and [PRs](https://github.com/bids-standard/bids-specification/pulls) in bids-specification
+

--- a/spec_update_issue_template.md
+++ b/spec_update_issue_template.md
@@ -11,7 +11,6 @@ What `limitation in the current spec` does this underline ?*
 *Provide a minimal example with the current spec.
 How would this example turn if we `apply the proposed change` ?*
 
--------------
 ### Checklist 
 - [ ] links to related existing [issues](https://github.com/bids-standard/BEP028_BIDSprov/issues) and/or [PR](https://github.com/bids-standard/BEP028_BIDSprov/pulls)
 


### PR DESCRIPTION
Issue template to follow every time
Example using this template to propose type indexing in BIDS-prov

## Type-indexing on agents/activities/entities in BIDS-prov
--------------
### Problem Statement
When defining new graphs in BIDS-prov we have no way to know the type of an object in advance.
If we want to find all entities in a given graph, we must iterate over the entire graph.
In addition, this layout currently makes reading of the graph harder, and spotting errors becomes tedious

--------------
### Rationale
We propose to use a feature called type indexing, for all our graphs
This will allow to group nodes by type, and maybe to create a hierarchy in the future, accessing the most basic types at first and then descending in the graph for more specific types (eg. Agent vs Software Agent)

--------------
### Minimal examples
#### Before
```json
"@graph": [
        {
          "@id" : "dfsiosndfn1",
          "label" : "realign",
          "@type" : "prov:Activity",
        },
]
```

#### After
```json
"@graph": {
        "prov:Activity" : [
        {
          "@id" : "dfsiosndfn1",
          "label" : "realign",
        },
    ]
}
```
-------------
### Checklist 

- [X] link to the google doc of the proposal : [here](https://docs.google.com/document/d/1vw3VNDof5cecv2PkFp7Lw_pNUTUo8-m8V4SIdtGJVKs/edit#)
- [X] make sure the google doc follows the [BIDS proposale template](https://docs.google.com/document/d/1W7--Mf3gCCb1mVfhsoRJCAKFhmf2umG1PFkyZ1jEgMw/edit#heading=h.4k1noo90gelw)
- [X] list of all authors for this proposal : Satra Ghosh, Camille Maumet
- [X] links to related [issues](https://github.com/bids-standard/bids-specification/issues) and [PRs](https://github.com/bids-standard/bids-specification/pulls) in bids-specification


