### PR TITLE
rm wasAttributedTo ?

### DIFF
--- a/bids_prov/spm_load_config.py
+++ b/bids_prov/spm_load_config.py
@@ -19,6 +19,8 @@ CONTEXT_URL = "https://raw.githubusercontent.com/cmaumet/BIDS-prov/context-type-
 with open(this_path + "/spm_config.yml", "r") as fd:
     static = yaml.load(fd)
 
+SPM_RRID = "RRID:SCR_007037"  # TODO query for version
+
 
 def get_empty_graph(context_url=CONTEXT_URL):
     return {
@@ -38,7 +40,7 @@ def get_empty_graph(context_url=CONTEXT_URL):
         "records": {
             "prov:Agent": [
                 {
-                    "@id": "RRID:SCR_007037",  # TODO query for version
+                    "@id": SPM_RRID,
                     "@type": "prov:SoftwareAgent",
                     "label": "SPM",
                 }

--- a/bids_prov/spm_parser.py
+++ b/bids_prov/spm_parser.py
@@ -40,7 +40,6 @@ def get_input_entity(left, right):
         "@id": "niiri:" + entity_label + get_id(),
         "label": entity_label,
         "prov:atLocation": right[2:-3],
-        "wasAttributedTo": conf.SPM_RRID,
     }
     return entity
 
@@ -161,7 +160,6 @@ def get_records(task_groups: dict, records=defaultdict(list)):
                             "label": parts[-1],
                             # "prov:atLocation": TODO
                             "wasGeneratedBy": closest_activity["@id"],
-                            "wasAttributedTo": conf.SPM_RRID,
                         }
                     )
                 else:

--- a/bids_prov/spm_parser.py
+++ b/bids_prov/spm_parser.py
@@ -3,7 +3,6 @@ import click
 import json
 import os
 import re
-from difflib import SequenceMatcher
 
 from collections import defaultdict
 
@@ -41,7 +40,7 @@ def get_input_entity(left, right):
         "@id": "niiri:" + entity_label + get_id(),
         "label": entity_label,
         "prov:atLocation": right[2:-3],
-        # "wasAttributedTo": "RRID:SCR_007037",
+        "wasAttributedTo": conf.SPM_RRID,
     }
     return entity
 
@@ -50,13 +49,6 @@ def preproc_param_value(val):
     if val[0] == "[":
         return val.replace(" ", ", ")
     return val
-
-
-def readlines(filename):
-    with open(filename) as fd:
-        for line in fd:
-            if line.startswith("matlabbatch"):
-                yield line[:-1]  # remove "\n"
 
 
 def group_lines(lines):
@@ -82,16 +74,19 @@ def group_lines(lines):
     {'file_ops.file_move._1': ['call', 'different.call']}
     """
     res = defaultdict(list)
+
     for line in lines:
-        a = re.search(r"\{\d+\}", line)
+        a = re.search(r"matlabbatch(\{\d+\})", line)
         if a:
-            g = a.group()[1:-1]
+            g = int(a.group(1)[1:-1])
+            if res and max(res.keys()) > g:
+                g += max(res.keys())
             res[g].append(line[a.end() + 1 :])
 
     new_res = dict()
     for k, v in res.items():
         common_prefix = os.path.commonprefix([_.split(" = ")[0] for _ in v])
-        new_key = f"{common_prefix}_{k}"
+        new_key = f"{common_prefix}_{str(k)}"
         new_res[new_key] = [_[len(common_prefix) :] for _ in v]
     return new_res
 
@@ -106,12 +101,12 @@ def get_records(task_groups: dict, records=defaultdict(list)):
     """
     entities_ids = set()
     for activity_name, values in task_groups.items():
-        activity_id = "niiri:" + activity_name + get_id()
+        activity_id = "niiri:" + re.sub(r"[\{\}]", "", activity_name) + get_id()
         activity = {
             "@id": activity_id,
             "label": format_activity_name(activity_name),
             "used": list(),
-            "wasAssociatedWith": "RRID:SCR_007037",
+            "wasAssociatedWith": conf.SPM_RRID,
         }
         input_entities, output_entities = list(), list()
         params = []
@@ -166,7 +161,7 @@ def get_records(task_groups: dict, records=defaultdict(list)):
                             "label": parts[-1],
                             # "prov:atLocation": TODO
                             "wasGeneratedBy": closest_activity["@id"],
-                            # "wasAttributedTo": "RRID:SCR_007037",
+                            "wasAttributedTo": conf.SPM_RRID,
                         }
                     )
                 else:
@@ -215,8 +210,8 @@ def spm_to_bids_prov(filenames, output_file, context_url):
 
     graph = conf.get_empty_graph(context_url=context_url)
 
-    lines = readlines(filename)
-    tasks = group_lines(lines)
+    with open(filename) as fd:
+        tasks = group_lines(fd)
     records = get_records(tasks)
     graph["records"].update(records)
 

--- a/context.json
+++ b/context.json
@@ -20,10 +20,6 @@
           "@id": "http://www.w3.org/ns/prov#wasGeneratedBy",
           "@type": "http://www.w3.org/2001/XMLSchema#Entity"
         },
-        "wasAttributedTo" : {
-          "@id": "http://www.w3.org/ns/prov#wasAttributedTo",
-          "@type": "http://www.w3.org/2001/XMLSchema#Agent"
-        },
         "wasAssociatedWith" : {
           "@id": "http://www.w3.org/ns/prov#wasAssociatedWith",
           "@type": "http://www.w3.org/2001/XMLSchema#Agent"

--- a/examples/fmriprep/simple.json
+++ b/examples/fmriprep/simple.json
@@ -27,7 +27,7 @@
             "@id": "niiri:dsk100010",
             "label": "preprocessed functional images",
             "prov:atLocation": "niiri:bids-input-dir/T1/*.nii.gz",
-            "attributedTo": "RRID:SCR_016216",
+            "wasAttributedTo": "RRID:SCR_016216",
             "wasGeneratedBy": "niiri:1489292_call"
         }
       ]

--- a/examples/fmriprep/simple.json
+++ b/examples/fmriprep/simple.json
@@ -27,7 +27,7 @@
             "@id": "niiri:dsk100010",
             "label": "preprocessed functional images",
             "prov:atLocation": "niiri:bids-input-dir/T1/*.nii.gz",
-            "wasAttributedTo": "RRID:SCR_016216",
+            
             "wasGeneratedBy": "niiri:1489292_call"
         }
       ]

--- a/examples/fsl_default/default.json
+++ b/examples/fsl_default/default.json
@@ -61,39 +61,39 @@
         "@id": "niiri:dskjn1902",
         "label": "functional",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823"
+        "wasAttributedTo": "RRID:SCR_002823"
       },
       {
         "@id": "niiri:ksdqndns100201",
         "label": "Aligned functional",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823",
+        "wasAttributedTo": "RRID:SCR_002823",
         "wasGeneratedBy": "niiri:sqlspspsppsp20202"
       },
       {
         "@id": "niiri:vbvbbvbv_undistorted_func",
         "label": "un-distorted functional",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184",
+        "wasAttributedTo": "RRID:SCR_00184",
         "wasGeneratedBy": "niiri:fsqjklnfqljnfnfnnf_unwarp"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_contrasts",
         "label": "contrasts",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184"
+        "wasAttributedTo": "RRID:SCR_00184"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_design_matrix",
         "label": "Design matrix",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184"
+        "wasAttributedTo": "RRID:SCR_00184"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_prestats_output",
         "label": "Prestats output",
         "prov:atLocation": "TODO",
-        "attributedTo": "RRID:SCR_00184",
+        "wasAttributedTo": "RRID:SCR_00184",
         "wasGeneratedBy": "niiri:fsqjklnfqljnfnfnnf_prestats"
       }
     ]

--- a/examples/fsl_default/default.json
+++ b/examples/fsl_default/default.json
@@ -61,39 +61,39 @@
         "@id": "niiri:dskjn1902",
         "label": "functional",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_002823"
+        
       },
       {
         "@id": "niiri:ksdqndns100201",
         "label": "Aligned functional",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_002823",
+        
         "wasGeneratedBy": "niiri:sqlspspsppsp20202"
       },
       {
         "@id": "niiri:vbvbbvbv_undistorted_func",
         "label": "un-distorted functional",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:fsqjklnfqljnfnfnnf_unwarp"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_contrasts",
         "label": "contrasts",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_00184"
+        
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_design_matrix",
         "label": "Design matrix",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_00184"
+        
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_prestats_output",
         "label": "Prestats output",
         "prov:atLocation": "TODO",
-        "wasAttributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:fsqjklnfqljnfnfnnf_prestats"
       }
     ]

--- a/examples/fsl_default/group_analysis.json
+++ b/examples/fsl_default/group_analysis.json
@@ -13,21 +13,21 @@
         "@id": "niiri:rezoiurozeiuriozuro",
         "label": "Transformation files",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:qndjnqndnfsdnfnsdf_registration"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_copes",
         "label": "copes",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:qndjnqndnfsdnfnsdf_registration"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_varcopes",
         "label": "varcopes",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:qndjnqndnfsdnfnsdf_registration"
       }
     ]

--- a/examples/fsl_default/group_analysis.json
+++ b/examples/fsl_default/group_analysis.json
@@ -13,21 +13,21 @@
         "@id": "niiri:rezoiurozeiuriozuro",
         "label": "Transformation files",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184",
+        "wasAttributedTo": "RRID:SCR_00184",
         "wasGeneratedBy": "niiri:qndjnqndnfsdnfnsdf_registration"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_copes",
         "label": "copes",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184",
+        "wasAttributedTo": "RRID:SCR_00184",
         "wasGeneratedBy": "niiri:qndjnqndnfsdnfnsdf_registration"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_varcopes",
         "label": "varcopes",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184",
+        "wasAttributedTo": "RRID:SCR_00184",
         "wasGeneratedBy": "niiri:qndjnqndnfsdnfnsdf_registration"
       }
     ]

--- a/examples/fsl_default/single_subject_inference.json
+++ b/examples/fsl_default/single_subject_inference.json
@@ -23,20 +23,20 @@
         "@id": "niiri:dskjn1904_zstats",
         "label": "zstats.nii.gz",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823",
+        "wasAttributedTo": "RRID:SCR_002823",
         "wasGeneratedBy": "niiri:fsqjklnfqljnfnfnnf_stats"
       },
       {
         "@id": "niiri:dskjn1904_thresh",
         "label": "tresholds",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823"
+        "wasAttributedTo": "RRID:SCR_002823"
       },
       {
         "@id": "niiri:dskjn1904_results",
         "label": "results",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823",
+        "wasAttributedTo": "RRID:SCR_002823",
         "wasGeneratedBy": "niiri:sqlspspsppsp_significance_testing"
       }
     ]

--- a/examples/fsl_default/single_subject_inference.json
+++ b/examples/fsl_default/single_subject_inference.json
@@ -23,20 +23,20 @@
         "@id": "niiri:dskjn1904_zstats",
         "label": "zstats.nii.gz",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_002823",
+        
         "wasGeneratedBy": "niiri:fsqjklnfqljnfnfnnf_stats"
       },
       {
         "@id": "niiri:dskjn1904_thresh",
         "label": "tresholds",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_002823"
+        
       },
       {
         "@id": "niiri:dskjn1904_results",
         "label": "results",
         "prov:atLocation": "niiri:TODO",
-        "wasAttributedTo": "RRID:SCR_002823",
+        
         "wasGeneratedBy": "niiri:sqlspspsppsp_significance_testing"
       }
     ]

--- a/examples/spm_default/copies.json
+++ b/examples/spm_default/copies.json
@@ -56,7 +56,7 @@
         "label": "anat unzipped",
         "prov:atLocation": "??????",
         "derivedFrom": "niiri:sjhgdfhjsgd63q5aaafa",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:6534673543aaaaaaa"
       },
       {
@@ -64,7 +64,7 @@
         "label": "func unzipped",
         "prov:atLocation": "$HOME/nidm-results-examples/spm_default/ds011/PREPROCESSING/FUNCTIONAL/*",
         "derivedFrom": "niiri:sjhgdf673gbdsjdfsqjnfd",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:653467354367537g345523efdghs"
       }
     ]

--- a/examples/spm_default/copies.json
+++ b/examples/spm_default/copies.json
@@ -56,7 +56,7 @@
         "label": "anat unzipped",
         "prov:atLocation": "??????",
         "derivedFrom": "niiri:sjhgdfhjsgd63q5aaafa",
-        "attributedTo": "RRID:SCR_007037",
+        "wasAttributedTo": "RRID:SCR_007037",
         "wasGeneratedBy": "niiri:6534673543aaaaaaa"
       },
       {
@@ -64,7 +64,7 @@
         "label": "func unzipped",
         "prov:atLocation": "$HOME/nidm-results-examples/spm_default/ds011/PREPROCESSING/FUNCTIONAL/*",
         "derivedFrom": "niiri:sjhgdf673gbdsjdfsqjnfd",
-        "attributedTo": "RRID:SCR_007037",
+        "wasAttributedTo": "RRID:SCR_007037",
         "wasGeneratedBy": "niiri:653467354367537g345523efdghs"
       }
     ]

--- a/examples/spm_default/coreg_and_segment.json
+++ b/examples/spm_default/coreg_and_segment.json
@@ -93,7 +93,7 @@
       {
         "@id": "niiri:fsiudfqsoi938409283409fdskj",
         "label": ".nii updated header",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fdsljfnqkljfdklqsjdfq",
         "derivedFrom": [
           "niiri:fdsjnflqj12381U39fdskjnf",
@@ -104,7 +104,7 @@
       {
         "@id": "niiri:102983fsdkjnfskjdfnks129",
         "label": "anat bias corrected",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/"
@@ -112,7 +112,7 @@
       {
         "@id": "niiri:fsiud1",
         "label": "tissue1",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,1"
@@ -120,7 +120,7 @@
       {
         "@id": "niiri:fsiud2",
         "label": "tissue2",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,2"
@@ -128,7 +128,7 @@
       {
         "@id": "niiri:fsiud3",
         "label": "tissue3",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,3"
@@ -136,7 +136,7 @@
       {
         "@id": "niiri:fsiud4",
         "label": "tissue4",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,4"
@@ -144,7 +144,7 @@
       {
         "@id": "niiri:fsiud5",
         "label": "tisue5",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,5"
@@ -152,7 +152,7 @@
       {
         "@id": "niiri:fsiud6",
         "label": "tissue6",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,6"

--- a/examples/spm_default/model_and_contrast.json
+++ b/examples/spm_default/model_and_contrast.json
@@ -64,7 +64,7 @@
         "@id": "niiri:dsjknl1029d",
         "label": "SPM.mat",
         "prov:atLocation": "TODO",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fsdfksnf1290883",
         "prov:wasInfluencedBy": "niiri:fsdfksnf1290883"
       }

--- a/examples/spm_default/normalise.json
+++ b/examples/spm_default/normalise.json
@@ -43,7 +43,7 @@
         "@id": "niiri:2378783298182821NDN",
         "label": "normalised func",
         "prov:atLocation": "func_normalised_location.nii",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fsdknfsqkldf12238123818288",
         "derivedFrom": "niiri:fdsjnflqj12381U39fdskjnf"
       },
@@ -51,7 +51,7 @@
         "@id": "niiri:12837873NDN",
         "label": "normalised anat",
         "prov:atLocation": "anat_normalised_location.nii",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fsdknfsqkld123980932",
         "derivedFrom": "niiri:102983fsdkjnfskjdfnks129"
       }

--- a/examples/spm_default/realign.json
+++ b/examples/spm_default/realign.json
@@ -46,7 +46,7 @@
     "prov:Entity": [
       {
         "@id": "niiri:fdsjnflqj12381U39fdskjnf",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fdskjfnskjndflqkjndl",
         "derivedFrom": "niiri:sjhgdqd",
         "label": "Realigned func",

--- a/examples/spm_default/report.json
+++ b/examples/spm_default/report.json
@@ -37,7 +37,7 @@
         "generatedAt": "2019-10-10T10:00:00",
         "derivedFrom": "niiri:dsjknl1029d",
         "wasGeneratedBy": "niiri:qkjsnd1283NDQSNKDQ",
-        "wasAttributedTo": "RRID:SCR_007037"
+        
       }
     ]
   }

--- a/examples/spm_default/smooth.json
+++ b/examples/spm_default/smooth.json
@@ -41,7 +41,7 @@
         "@id": "niiri:fjsdnf290",
         "label": "Smoothed functional images",
         "prov:atLocation": "TODO",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:smm343",
         "derivedFrom": "niiri:2378783298182821NDN"
       }


### PR DESCRIPTION
This PR discusses the `wasAttributedTo` attribute that one can fill in the definition of an entity, in order to refer to the Agent in charge.

IMO we should remove `wasAttributedTo`, it's only redundant information w.r.t querying `wasGeneratedBy` and then `wasAssociatedWith`, going from the original entity to its related activity, and from this activity to the related Agent.

In addition, this field makes graphs less interpretable, by adding edges 
![test](https://user-images.githubusercontent.com/2931080/122547431-64052b00-d030-11eb-8ff0-51be37896b6c.png)


