### PR TITLE
[RM] wasAttributedTo

### DIFF
--- a/bids_prov/spm_parser.py
+++ b/bids_prov/spm_parser.py
@@ -41,7 +41,6 @@ def get_input_entity(left, right):
         "@id": "niiri:" + entity_label + get_id(),
         "label": entity_label,
         "prov:atLocation": right[2:-3],
-        # "wasAttributedTo": "RRID:SCR_007037",
     }
     return entity
 
@@ -166,7 +165,7 @@ def get_records(task_groups: dict, records=defaultdict(list)):
                             "label": parts[-1],
                             # "prov:atLocation": TODO
                             "wasGeneratedBy": closest_activity["@id"],
-                            # "wasAttributedTo": "RRID:SCR_007037",
+                            #
                         }
                     )
                 else:

--- a/bids_prov/spm_parser.py
+++ b/bids_prov/spm_parser.py
@@ -54,6 +54,9 @@ def preproc_param_value(val):
 def readlines(filename):
     with open(filename) as fd:
         for line in fd:
+            if line.count("{") != line.count("}"):
+                # TODO handle multiline definition
+                continue
             if line.startswith("matlabbatch"):
                 yield line[:-1]  # remove "\n"
 

--- a/context.json
+++ b/context.json
@@ -20,10 +20,6 @@
           "@id": "http://www.w3.org/ns/prov#wasGeneratedBy",
           "@type": "http://www.w3.org/2001/XMLSchema#Entity"
         },
-        "wasAttributedTo" : {
-          "@id": "http://www.w3.org/ns/prov#wasAttributedTo",
-          "@type": "http://www.w3.org/2001/XMLSchema#Agent"
-        },
         "wasAssociatedWith" : {
           "@id": "http://www.w3.org/ns/prov#wasAssociatedWith",
           "@type": "http://www.w3.org/2001/XMLSchema#Agent"

--- a/examples/fmriprep/simple.json
+++ b/examples/fmriprep/simple.json
@@ -27,7 +27,7 @@
             "@id": "niiri:dsk100010",
             "label": "preprocessed functional images",
             "prov:atLocation": "niiri:bids-input-dir/T1/*.nii.gz",
-            "attributedTo": "RRID:SCR_016216",
+            
             "wasGeneratedBy": "niiri:1489292_call"
         }
       ]

--- a/examples/fsl_default/default.json
+++ b/examples/fsl_default/default.json
@@ -61,39 +61,39 @@
         "@id": "niiri:dskjn1902",
         "label": "functional",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823"
+        
       },
       {
         "@id": "niiri:ksdqndns100201",
         "label": "Aligned functional",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823",
+        
         "wasGeneratedBy": "niiri:sqlspspsppsp20202"
       },
       {
         "@id": "niiri:vbvbbvbv_undistorted_func",
         "label": "un-distorted functional",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:fsqjklnfqljnfnfnnf_unwarp"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_contrasts",
         "label": "contrasts",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184"
+        
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_design_matrix",
         "label": "Design matrix",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184"
+        
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_prestats_output",
         "label": "Prestats output",
         "prov:atLocation": "TODO",
-        "attributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:fsqjklnfqljnfnfnnf_prestats"
       }
     ]

--- a/examples/fsl_default/group_analysis.json
+++ b/examples/fsl_default/group_analysis.json
@@ -13,21 +13,21 @@
         "@id": "niiri:rezoiurozeiuriozuro",
         "label": "Transformation files",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:qndjnqndnfsdnfnsdf_registration"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_copes",
         "label": "copes",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:qndjnqndnfsdnfnsdf_registration"
       },
       {
         "@id": "niiri:dfsjnsqkdfnjsn_varcopes",
         "label": "varcopes",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_00184",
+        
         "wasGeneratedBy": "niiri:qndjnqndnfsdnfnsdf_registration"
       }
     ]

--- a/examples/fsl_default/single_subject_inference.json
+++ b/examples/fsl_default/single_subject_inference.json
@@ -23,20 +23,20 @@
         "@id": "niiri:dskjn1904_zstats",
         "label": "zstats.nii.gz",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823",
+        
         "wasGeneratedBy": "niiri:fsqjklnfqljnfnfnnf_stats"
       },
       {
         "@id": "niiri:dskjn1904_thresh",
         "label": "tresholds",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823"
+        
       },
       {
         "@id": "niiri:dskjn1904_results",
         "label": "results",
         "prov:atLocation": "niiri:TODO",
-        "attributedTo": "RRID:SCR_002823",
+        
         "wasGeneratedBy": "niiri:sqlspspsppsp_significance_testing"
       }
     ]

--- a/examples/spm_default/copies.json
+++ b/examples/spm_default/copies.json
@@ -56,7 +56,7 @@
         "label": "anat unzipped",
         "prov:atLocation": "??????",
         "derivedFrom": "niiri:sjhgdfhjsgd63q5aaafa",
-        "attributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:6534673543aaaaaaa"
       },
       {
@@ -64,7 +64,7 @@
         "label": "func unzipped",
         "prov:atLocation": "$HOME/nidm-results-examples/spm_default/ds011/PREPROCESSING/FUNCTIONAL/*",
         "derivedFrom": "niiri:sjhgdf673gbdsjdfsqjnfd",
-        "attributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:653467354367537g345523efdghs"
       }
     ]

--- a/examples/spm_default/coreg_and_segment.json
+++ b/examples/spm_default/coreg_and_segment.json
@@ -93,7 +93,7 @@
       {
         "@id": "niiri:fsiudfqsoi938409283409fdskj",
         "label": ".nii updated header",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fdsljfnqkljfdklqsjdfq",
         "derivedFrom": [
           "niiri:fdsjnflqj12381U39fdskjnf",
@@ -104,7 +104,7 @@
       {
         "@id": "niiri:102983fsdkjnfskjdfnks129",
         "label": "anat bias corrected",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/"
@@ -112,7 +112,7 @@
       {
         "@id": "niiri:fsiud1",
         "label": "tissue1",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,1"
@@ -120,7 +120,7 @@
       {
         "@id": "niiri:fsiud2",
         "label": "tissue2",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,2"
@@ -128,7 +128,7 @@
       {
         "@id": "niiri:fsiud3",
         "label": "tissue3",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,3"
@@ -136,7 +136,7 @@
       {
         "@id": "niiri:fsiud4",
         "label": "tissue4",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,4"
@@ -144,7 +144,7 @@
       {
         "@id": "niiri:fsiud5",
         "label": "tisue5",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,5"
@@ -152,7 +152,7 @@
       {
         "@id": "niiri:fsiud6",
         "label": "tissue6",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:sdfsdofjiosdf",
         "derivedFrom": "niiri:fsiudfqsoi938409283409fdskj",
         "prov:atLocation": "$HOME/spm12/tpm/TPM.nii,6"

--- a/examples/spm_default/model_and_contrast.json
+++ b/examples/spm_default/model_and_contrast.json
@@ -64,7 +64,7 @@
         "@id": "niiri:dsjknl1029d",
         "label": "SPM.mat",
         "prov:atLocation": "TODO",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fsdfksnf1290883",
         "prov:wasInfluencedBy": "niiri:fsdfksnf1290883"
       }

--- a/examples/spm_default/normalise.json
+++ b/examples/spm_default/normalise.json
@@ -43,7 +43,7 @@
         "@id": "niiri:2378783298182821NDN",
         "label": "normalised func",
         "prov:atLocation": "func_normalised_location.nii",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fsdknfsqkldf12238123818288",
         "derivedFrom": "niiri:fdsjnflqj12381U39fdskjnf"
       },
@@ -51,7 +51,7 @@
         "@id": "niiri:12837873NDN",
         "label": "normalised anat",
         "prov:atLocation": "anat_normalised_location.nii",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fsdknfsqkld123980932",
         "derivedFrom": "niiri:102983fsdkjnfskjdfnks129"
       }

--- a/examples/spm_default/realign.json
+++ b/examples/spm_default/realign.json
@@ -46,7 +46,7 @@
     "prov:Entity": [
       {
         "@id": "niiri:fdsjnflqj12381U39fdskjnf",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:fdskjfnskjndflqkjndl",
         "derivedFrom": "niiri:sjhgdqd",
         "label": "Realigned func",

--- a/examples/spm_default/report.json
+++ b/examples/spm_default/report.json
@@ -37,7 +37,7 @@
         "generatedAt": "2019-10-10T10:00:00",
         "derivedFrom": "niiri:dsjknl1029d",
         "wasGeneratedBy": "niiri:qkjsnd1283NDQSNKDQ",
-        "wasAttributedTo": "RRID:SCR_007037"
+        
       }
     ]
   }

--- a/examples/spm_default/smooth.json
+++ b/examples/spm_default/smooth.json
@@ -41,7 +41,7 @@
         "@id": "niiri:fjsdnf290",
         "label": "Smoothed functional images",
         "prov:atLocation": "TODO",
-        "wasAttributedTo": "RRID:SCR_007037",
+        
         "wasGeneratedBy": "niiri:smm343",
         "derivedFrom": "niiri:2378783298182821NDN"
       }


### PR DESCRIPTION
"wasAttributedTo" contains duplicate informations w.r.t `wasGeneratedBy` + `wasAssociatedWith`

Plus we already removed it from our SPM parser, as the resulting graph was visually not interpretable

removing it