### PR TITLE
SPM parser parser multilines

### DIFF
--- a/bids_prov/spm_parser.py
+++ b/bids_prov/spm_parser.py
@@ -52,13 +52,20 @@ def preproc_param_value(val):
 
 
 def readlines(filename):
+    """Read lines from the original batch.m file
+
+    A definition should be associated with a single line in the output
+    """
     with open(filename) as fd:
         for line in fd:
             if line.count("{") != line.count("}"):
                 # TODO handle multiline definition
                 continue
             if line.startswith("matlabbatch"):
-                yield line[:-1]  # remove "\n"
+                _line = line[:-1]
+                while _line.count("{") != _line.count("}"):
+                    _line += next(fd, "} ")[:-1].lstrip() + ","
+                yield _line  # remove "\n"
 
 
 def group_lines(lines):

--- a/bids_prov/spm_parser.py
+++ b/bids_prov/spm_parser.py
@@ -58,9 +58,6 @@ def readlines(filename):
     """
     with open(filename) as fd:
         for line in fd:
-            if line.count("{") != line.count("}"):
-                # TODO handle multiline definition
-                continue
             if line.startswith("matlabbatch"):
                 _line = line[:-1]
                 while _line.count("{") != _line.count("}"):


### PR DESCRIPTION
allowing definitions to be spread across multiple lines

Here is the set of entities generated from the OLS batch.m

```json
    "prov:Entity": [
      {
        "@id": "niiri:con_0001.nii,1,,kXeLuuIRbn",
        "label": "con_0001.nii,1,,",
        "prov:atLocation": "/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-01/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-02/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-03/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-04/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-05/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-06/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-07/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-08/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-09/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-10/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-11/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-12/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-13/con_0001.nii,1','/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/EXAMPLES/ds011/SPM/LEVEL1/sub-14/con_0001.nii,1',"
      },
      {
        "@id": "niiri:SPM.matFile1",
        "label": "SPM.mat File",
        "wasGeneratedBy": "niiri:spm.stats.factorial_design._1lTydXQTXPC"
      },
      {
        "@id": "niiri:SPM.matFile2",
        "label": "SPM.mat File",
        "wasGeneratedBy": "niiri:spm.stats.fmri_est._2ZjVigkMsxQ"
      },
      {
        "@id": "niiri:SPM.matFile3",
        "label": "SPM.mat File",
        "wasGeneratedBy": "niiri:spm.stats.con._3VdNFeYjPyj"
      }
    ]
```

and here is how it was before this PR (just ignoring those lines)
```json
"prov:Entity": [
      {
        "@id": "niiri:SPM.matFile1",
        "label": "SPM.mat File",
        "wasGeneratedBy": "niiri:spm.stats.factorial_design._1CwgGThZjgs"
      },
      {
        "@id": "niiri:SPM.matFile2",
        "label": "SPM.mat File",
        "wasGeneratedBy": "niiri:spm.stats.fmri_est._2yTIuYWUHyE"
      },
      {
        "@id": "niiri:SPM.matFile3",
        "label": "SPM.mat File",
        "wasGeneratedBy": "niiri:spm.stats.con._3VlKcLunUQg"
      }
    ]
```