### PR TITLE
remove second `StartedAtTime`

### DIFF
--- a/context.json
+++ b/context.json
@@ -15,10 +15,6 @@
           "@id": "prov:startedAtTime",
           "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
         },
-        "StartedAtTime" : {
-          "@id": "prov:endedAtTime",
-          "@type": "xsd:dateTime"
-        },
         "EndedAtTime" : {
           "@id": "prov:endedAtTime",
           "@type": "xsd:dateTime"


### PR DESCRIPTION
remove the following, which seems to be repetitive and not correct
```

        "StartedAtTime" : {
          "@id": "prov:endedAtTime",
          "@type": "xsd:dateTime"
        },
```