### PR TITLE
Codespell skipping `examples/from_parsers`

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .git,*.pdf,*.svg,venvs
+skip = .git,*.pdf,*.svg,venvs,./examples/from_parsers
 #
 # ignore-words-list =

--- a/examples/from_parsers/context_2024_05_22_14h49m45s.txt
+++ b/examples/from_parsers/context_2024_05_22_14h49m45s.txt
@@ -1,4 +1,4 @@
-Date : 2024_05_22_14h39m45s
+Date : 2024_05_22_14h49m45s
 Processing files...
     file= nidmresults-examples/afni_alt_onesided_proc.sub_001
     file= nidmresults-examples/afni_alt_onesided_proc.sub_001
@@ -69,4 +69,4 @@ Processing files...
     file= nidmresults-examples/spm_thr_voxelfdrp05_batch.m
     file= nidmresults-examples/spm_thr_voxelfwep05_batch.m
     file= nidmresults-examples/spm_thr_voxelunct4_batch.m
-End of processed files. Results in dir : 'examples/from_parsers'. Time required: 0:01:20.463416
+End of processed files. Results in dir : 'examples/from_parsers'. Time required: 0:00:02.126340


### PR DESCRIPTION
Prevent the `codespell.yml` Github Actions workflow from checking files in `examples/from_parsers`.
Indeed, some of these files (list below) have codespell issues that cannot be corrected in this repository, as they come from the github.com/incf-nidash/nidmresults-examples/ repository.

```
Error: ./examples/from_parsers/afni/afni_hrf_gammadiff_proc.sub_001:329: colums ==> columns
Error: ./examples/from_parsers/afni/afni_con_f_proc.sub_001:326: colums ==> columns
Error: ./examples/from_parsers/afni/afni_thr_voxelunct4_proc.sub_001:326: colums ==> columns
Error: ./examples/from_parsers/afni/afni_thr_clustunck10_proc.sub_001:326: colums ==> columns
Error: ./examples/from_parsers/afni/afni_hrf_tent_proc.sub_001:331: colums ==> columns
Error: ./examples/from_parsers/afni/afni_gam_proc.sub_001:324: colums ==> columns
Error: ./examples/from_parsers/afni/afni_clustconn_18_proc.sub_001:326: colums ==> columns
Error: ./examples/from_parsers/afni/afni_bi_sided_t_test_proc.sub_001:326: colums ==> columns
Error: ./examples/from_parsers/afni/afni_default_proc.sub_001:328: colums ==> columns
Error: ./examples/from_parsers/afni/afni_clustconn_26_proc.sub_001:326: colums ==> columns
Error: ./examples/from_parsers/afni/afni_thr_voxelfdrp05_proc.sub_001:326: colums ==> columns
Error: ./examples/from_parsers/afni/afni_alt_onesided_proc.sub_001:326: colums ==> columns
Error: ./examples/from_parsers/afni/afni_other_template_proc.sub_001:328: colums ==> columns
Error: ./examples/from_parsers/afni/afni_thr_clustfwep05_proc.sub_001:326: colums ==> columns
```