### PR TITLE
Packaging the visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ venv*
 venv3.11/
 .idea/*
 .pytest_cache/*
+build/*
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -87,28 +87,33 @@ Mature building blocks of NIDM:
 ### Visualize your BIDSprov data
 
 To visualize your BIDSprov data, perform the following steps :
-1. [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the code inside a `BEP028_BIDSprov` directory ;
-2. in a terminal, change the current directory
+1. [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the code inside a `BEP028_BIDSprov` directory, and cd into this directory :
 
-`cd BEP028_BIDSprov`
+```shell
+git clone git@github.com:bids-standard/BEP028_BIDSprov.git
+cd BEP028_BIDSprov
+```
 
 3. install the `bids_prov` python package :
 
-`pip install .`
+```shell
+pip install .
+```
 
 4. you should be able to launch the visualizer on your .jsonld files with the command `bids_prov_visualizer`
 
-`bids_prov_visualizer --input_file graph.jsonld --output_file graph`
+```shell
+bids_prov_visualizer --input_file graph.jsonld --output_file graph.png
 
-```
-usage: bids_prov_visualizer [-h] --input_file INPUT_FILE [--output_file OUTPUT_FILE]
+bids_prov -h
+  usage: bids_prov_visualizer [-h] --input_file INPUT_FILE [--output_file OUTPUT_FILE]
 
-options:
-  -h, --help            show this help message and exit
-  --input_file INPUT_FILE
-                        input BIDSprov data as a .jsonld file
-  --output_file OUTPUT_FILE
-                        output .png file showing BIDSprov graph
+  options:
+    -h, --help            show this help message and exit
+    --input_file INPUT_FILE
+                          input BIDSprov data as a .jsonld file
+    --output_file OUTPUT_FILE
+                          output .png file showing BIDSprov graph
 ```
 
 ### Run parsers on the SPM, FSL and AFNI data

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Camille Maumet ([@cmaumet](https://github.com/cmaumet)) and Satrajit Ghosh ([@sa
 - Cyril Regan ([@cyril-data](https://github.com/cyril-data))<a href="https://github.com/bids-standard/BEP028_BIDSprov/commits?author=cyril-data" title="Code">💻</a><a href="https://github.com/bids-standard/BEP028_BIDSprov/pulls?q=is%3Apr+reviewed-by%3Acyril-data" title="Reviewed Pull Requests">👀</a><a href="https://github.com/bids-standard/BEP028_BIDSprov/commits?author=cyril-data" title="Documentation">📖</a>
 <a href="https://github.com/bids-standard/BEP028_BIDSprov/issues?q=author%3Acyril-data" title="Bug reports">🐛</a>
 
+- Boris Clénet ([@bclenet](https://github.com/bclenet))<a href="https://github.com/bids-standard/BEP028_BIDSprov/commits?author=bclenet" title="Code">💻</a><a href="https://github.com/bids-standard/BEP028_BIDSprov/commits?author=bclenet" title="Documentation">📖</a><a href="https://github.com/bids-standard/BEP028_BIDSprov/issues?q=author%3Abclenet" title="Bug reports">🐛</a>
+
 This project follows the
 [all-contributors](https://github.com/all-contributors/all-contributors)
 specification. Contributions of any kind welcome!
@@ -80,7 +82,36 @@ Mature building blocks of NIDM:
 [New features (to be included)](new_features.md)
 
 
-## Run parsers on the SPM, FSL and AFNI data
+## Using the code
+
+### Visualize your BIDSprov data
+
+To visualize your BIDSprov data, perform the following steps :
+1. [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the code inside a `BEP028_BIDSprov` directory ;
+2. in a terminal, change the current directory
+
+`cd BEP028_BIDSprov`
+
+3. install the `bids_prov` python package :
+
+`pip install .`
+
+4. you should be able to launch the visualizer on your .jsonld files with the command `bids_prov_visualizer`
+
+`bids_prov_visualizer --input_file graph.jsonld --output_file graph`
+
+```
+usage: bids_prov_visualizer [-h] --input_file INPUT_FILE [--output_file OUTPUT_FILE]
+
+options:
+  -h, --help            show this help message and exit
+  --input_file INPUT_FILE
+                        input BIDSprov data as a .jsonld file
+  --output_file OUTPUT_FILE
+                        output .png file showing BIDSprov graph
+```
+
+### Run parsers on the SPM, FSL and AFNI data
 
 To obtain data in **bids-prov format**, you can use the developed parsers.
 * [Tutorial](https://github.com/bids-standard/BEP028_BIDSprov/blob/master/bids_prov/README.md)

--- a/bids_prov/visualize.py
+++ b/bids_prov/visualize.py
@@ -114,8 +114,8 @@ def main(filename: str, output_file=None, omit_details=True) -> None:
 def entry_point():
     """ A command line tool for the visualize module """
     parser = argparse.ArgumentParser()
-    parser.add_argument("--input_file", type=str, default="res.jsonld", help="data jsonld file ")
-    parser.add_argument("--output_file", type=str, default="res.png", help="output dir where results are written")
+    parser.add_argument("--input_file", type=str, help="input BIDSprov data as a .jsonld file ", required=True)
+    parser.add_argument("--output_file", type=str, default="output_graph.png", help="output .png file showing BIDSprov graph")
     opt = parser.parse_args()
 
     main(opt.input_file, output_file=opt.output_file, omit_details=True)

--- a/bids_prov/visualize.py
+++ b/bids_prov/visualize.py
@@ -111,8 +111,8 @@ def main(filename: str, output_file=None, omit_details=True) -> None:
     viz_jsonld11(jsonld11, output_file)
 
 
-if __name__ == "__main__":
-
+def entry_point():
+    """ A command line tool for the visualize module """
     parser = argparse.ArgumentParser()
     parser.add_argument("--input_file", type=str, default="res.jsonld", help="data jsonld file ")
     parser.add_argument("--output_file", type=str, default="res.png", help="output dir where results are written")
@@ -120,3 +120,6 @@ if __name__ == "__main__":
 
     main(opt.input_file, output_file=opt.output_file, omit_details=True)
     # >> python -m   bids_prov.visualize --input_file ./res_temp.jsonld  --output_file res.png
+
+if __name__ == "__main__":
+    entry_point()

--- a/examples/from_parsers/context_2024_06_10_14h38m10s.txt
+++ b/examples/from_parsers/context_2024_06_10_14h38m10s.txt
@@ -1,4 +1,4 @@
-Date : 2024_05_23_08h10m05s
+Date : 2024_06_10_14h38m10s
 Processing files...
     file= nidmresults-examples/afni_alt_onesided_proc.sub_001
     file= nidmresults-examples/afni_alt_onesided_proc.sub_001
@@ -69,4 +69,4 @@ Processing files...
     file= nidmresults-examples/spm_thr_voxelfdrp05_batch.m
     file= nidmresults-examples/spm_thr_voxelfwep05_batch.m
     file= nidmresults-examples/spm_thr_voxelunct4_batch.m
-End of processed files. Results in dir : 'examples/from_parsers'. Time required: 0:00:01.882820
+End of processed files. Results in dir : 'examples/from_parsers'. Time required: 0:00:01.877882

--- a/examples/from_parsers/context_2024_10_04_14h05m36s.txt
+++ b/examples/from_parsers/context_2024_10_04_14h05m36s.txt
@@ -1,4 +1,4 @@
-Date : 2024_06_10_14h38m10s
+Date : 2024_10_04_14h05m36s
 Processing files...
     file= nidmresults-examples/afni_alt_onesided_proc.sub_001
     file= nidmresults-examples/afni_alt_onesided_proc.sub_001
@@ -69,4 +69,4 @@ Processing files...
     file= nidmresults-examples/spm_thr_voxelfdrp05_batch.m
     file= nidmresults-examples/spm_thr_voxelfwep05_batch.m
     file= nidmresults-examples/spm_thr_voxelunct4_batch.m
-End of processed files. Results in dir : 'examples/from_parsers'. Time required: 0:00:01.877882
+End of processed files. Results in dir : 'examples/from_parsers'. Time required: 0:00:01.927037

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,4 @@ pre-commit = "^3.7.1"
 pytest-cov = "^5.0.0"
 
 [tool.poetry.scripts]
-bids_prov_visualizer = "bids_prov.visualize:main"
+bids_prov_visualizer = "bids_prov.visualize:entry_point"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,59 +1,56 @@
 [build-system]
-requires = [
-    "setuptools>=67.6.1, <67.7",
-    "wheel"
-    ]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
-[project]
+[tool.poetry]
 name = "bids_prov"
 authors = [
-    {name = "Camille Maumet"},
-    {name = "Satrajit Ghosh"},
-    {name = "Stefan Appelhoff"},
-    {name = "Chris Markiewicz"},
-    {name = "Yaroslav Halchenko"},
-    {name = "Jean-Baptiste Poline"},
-    {name = "Rémi Adon"},
-    {name = "Hermann Courteille"},
-    {name = "Thomas Betton"},
-    {name = "Cyril Regan"},
-    {name = "Boris Clénet"}
+    "Camille Maumet",
+    "Satrajit Ghosh",
+    "Stefan Appelhoff",
+    "Chris Markiewicz",
+    "Yaroslav Halchenko",
+    "Jean-Baptiste Poline",
+    "Rémi Adon",
+    "Hermann Courteille",
+    "Thomas Betton",
+    "Cyril Regan",
+    "Boris Clénet"
 ]
 description = "BIDS extension proposal 28 : BIDS Provenance"
 version = "0.1.0"
 readme = "README.md"
 requires-python = ">=3.10, <3.11"
-#keywords = ["one", "two"]
-license = {file = "LICENSE"}
+license = "CC-BY-4.0"
 classifiers = [
+    "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Medical Science Apps."
 ]
-dependencies = [
-    "beautifulsoup4>=4.12.3,<4.13",
-    "boutiques>=0.5.26,<0.6",
-    "click>=8.1.7,<8.2",
-    "deepdiff>=7.0.1,<7.1",
-    "graphviz>=0.20.3,<0.21",
-    "rdflib>=7.0.0,<7.1",
-    "rdflib-jsonld>=0.6.2,<0.7",
-    "prov>=2.0.0,<2.1",
-    "pydot>=2.0.0,<2.1",
-    "pyld>=2.0.4,<2.1",
-    "pyyaml>=6.0.1,<6.1",
-    "requests>=2.32.3,<2.33"
-]
+include = ["bids_prov/visualize.py"]
+exclude = ["bids_prov*"]
 
-[project.optional-dependencies]
-dev = [
-    "black",
-    "markdownify",
-    "pre-commit",
-    "pytest-cov"
-]
+[tool.poetry.dependencies]
+python = "^3.10.0"
+beautifulsoup4 = "^4.12.3"
+boutiques = "^0.5.26"
+click = "^8.1.7"
+deepdiff = "^7.0.1"
+graphviz = "^0.20.3"
+rdflib = "^7.0.0"
+rdflib-jsonld = "^0.6.2"
+prov = "^2.0.0"
+pydot = "^2.0.0"
+pyld = "^2.0.4"
+pyyaml = "^6.0.1"
+requests = "^2.32.3"
 
-[project.scripts]
-bids_prov_visualizer = 'bids_prov.visualize:main'
+[tool.poetry.group.dev.dependencies]
+black = "^24.4.2"
+markdownify = "^0.12.1"
+pre-commit = "^3.7.1"
+pytest-cov = "^5.0.0"
 
-[tool.setuptools]
-py-modules = ["bids_prov.visualize"]
+[tool.poetry.scripts]
+bids_prov_visualizer = "bids_prov.visualize:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,59 @@
+[build-system]
+requires = [
+    "setuptools>=67.6.1, <67.7",
+    "wheel"
+    ]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bids_prov"
+authors = [
+    {name = "Camille Maumet"},
+    {name = "Satrajit Ghosh"},
+    {name = "Stefan Appelhoff"},
+    {name = "Chris Markiewicz"},
+    {name = "Yaroslav Halchenko"},
+    {name = "Jean-Baptiste Poline"},
+    {name = "Rémi Adon"},
+    {name = "Hermann Courteille"},
+    {name = "Thomas Betton"},
+    {name = "Cyril Regan"},
+    {name = "Boris Clénet"}
+]
+description = "BIDS extension proposal 28 : BIDS Provenance"
+version = "0.1.0"
+readme = "README.md"
+requires-python = ">=3.10, <3.11"
+#keywords = ["one", "two"]
+license = {file = "LICENSE"}
+classifiers = [
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "beautifulsoup4>=4.12.3,<4.13",
+    "boutiques>=0.5.26,<0.6",
+    "click>=8.1.7,<8.2",
+    "deepdiff>=7.0.1,<7.1",
+    "graphviz>=0.20.3,<0.21",
+    "rdflib>=7.0.0,<7.1",
+    "rdflib-jsonld>=0.6.2,<0.7",
+    "prov>=2.0.0,<2.1",
+    "pydot>=2.0.0,<2.1",
+    "pyld>=2.0.4,<2.1",
+    "pyyaml>=6.0.1,<6.1",
+    "requests>=2.32.3,<2.33"
+]
+
+[project.optional-dependencies]
+dev = [
+    "black",
+    "markdownify",
+    "pre-commit",
+    "pytest-cov"
+]
+
+[project.scripts]
+bids_prov_visualizer = 'bids_prov.visualize:main'
+
+[tool.setuptools]
+py-modules = ["bids_prov.visualize"]


### PR DESCRIPTION
Closes #133

- Create a `pyproject.toml` file to be able to install the python code, e.g. using `pip install`
- Only the `bids_prov/visualize.py` is included in the package
- The `bids_prov_visualizer` command line tool (equivalent to `python -m bids_prov/visualize.py`) is provided